### PR TITLE
Remove navigation debounce

### DIFF
--- a/src/image_io.cpp
+++ b/src/image_io.cpp
@@ -53,26 +53,25 @@ void ViewerApp::LoadImageFromFile(const std::wstring& filePath, bool startAtEnd)
     CleanupPreloadingThreads();
     m_ctx.cancelPreloading = false;
     int mySeqId = ++m_ctx.loadSequenceId;
-
     m_ctx.isLoading = true;
     m_ctx.loadStartTime = GetTickCount64();
     SetTimer(m_ctx.hWnd, LOADING_TIMER_ID, 700, nullptr);
     m_ctx.loadingFilePath = filePath;
     m_ctx.startAtEnd = startAtEnd;
+
     {
         CriticalSectionLock lock(m_ctx.wicMutex);
-        // Keep current display resources alive until the replacement image is ready.
+        
+        // Keep current image resources alive for flicker-free loading    
         m_ctx.undoStack.clear();
         m_ctx.isHqPending = false;
         ++m_ctx.hqRenderSequenceId;
-        m_ctx.originalContainerFormat = GUID_NULL;
-
+        
         m_ctx.stagedFrames.clear();
         m_ctx.stagedDelays.clear();
         m_ctx.stagedWidth = 0;
         m_ctx.stagedHeight = 0;
         m_ctx.stagedOrientation = 1;
-
         m_ctx.stagedSvgData.clear();
     }
     m_ctx.currentFilePathOverride.clear();
@@ -441,14 +440,30 @@ std::vector<std::wstring> ViewerApp::ScanDirectory(const std::wstring& directory
 
 void ViewerApp::OnImageReady(bool success, int seqId) {
     if (m_ctx.loadSequenceId != seqId) return;
+
     if (success) {
         CriticalSectionLock lock(m_ctx.wicMutex);
+
         if (m_ctx.stagedFrames.empty() && m_ctx.stagedSvgData.empty()) {
             m_ctx.isLoading = false;
             return;
         }
 
-        ClearCurrentImageDisplayState();
+        // Clear the old image state before displaying new 
+        KillTimer(m_ctx.hWnd, ANIMATION_TIMER_ID);
+        m_ctx.d2dBitmap = nullptr;
+        m_ctx.d2dBitmapHq = nullptr;
+        m_ctx.animationD2DBitmaps.clear();
+        m_ctx.animationFrameConverters.clear();
+        m_ctx.animationFrameDelays.clear();
+        m_ctx.wicConverter = nullptr;
+        m_ctx.wicConverterOriginal = nullptr;
+        m_ctx.svgDocument = nullptr;
+        m_ctx.svgData.clear();
+        m_ctx.isSvg = false;
+        m_ctx.isAnimated = false;
+        m_ctx.rotationAngle = 0;
+        m_ctx.isFlippedHorizontal = false;
 
         if (!m_ctx.stagedSvgData.empty()) {
             m_ctx.svgData = std::move(m_ctx.stagedSvgData);
@@ -468,8 +483,11 @@ void ViewerApp::OnImageReady(bool success, int seqId) {
             }
 
             m_ctx.isAnimated = animated;
+            m_ctx.animationFrameConverters.clear();
+            m_ctx.animationFrameDelays.clear();
 
             // Determine start frame
+            m_ctx.currentAnimationFrame = 0;
             if (m_ctx.startAtEnd && !animated && !m_ctx.stagedFrames.empty()) {
                 m_ctx.currentAnimationFrame = static_cast<UINT>(m_ctx.stagedFrames.size() - 1);
             }
@@ -638,25 +656,6 @@ void ViewerApp::CleanupLoadingThread() {
     m_ctx.cancelPreloading = true;
     CleanupPreloadingThreads();
     KillTimer(m_ctx.hWnd, ANIMATION_TIMER_ID);
-}
-
-void ViewerApp::ClearCurrentImageDisplayState() {
-    KillTimer(m_ctx.hWnd, ANIMATION_TIMER_ID);
-    m_ctx.wicConverter = nullptr;
-    m_ctx.wicConverterOriginal = nullptr;
-    m_ctx.d2dBitmap = nullptr;
-    m_ctx.d2dBitmapHq = nullptr;
-    m_ctx.isHqPending = false;
-    m_ctx.animationD2DBitmaps.clear();
-    m_ctx.animationFrameConverters.clear();
-    m_ctx.animationFrameDelays.clear();
-    m_ctx.currentAnimationFrame = 0;
-    m_ctx.isAnimated = false;
-    m_ctx.isSvg = false;
-    m_ctx.svgDocument = nullptr;
-    m_ctx.svgData.clear();
-    m_ctx.rotationAngle = 0;
-    m_ctx.isFlippedHorizontal = false;
 }
 
 void ViewerApp::CleanupPreloadingThreads() {

--- a/src/image_io.cpp
+++ b/src/image_io.cpp
@@ -61,22 +61,11 @@ void ViewerApp::LoadImageFromFile(const std::wstring& filePath, bool startAtEnd)
     m_ctx.startAtEnd = startAtEnd;
     {
         CriticalSectionLock lock(m_ctx.wicMutex);
-        m_ctx.wicConverter = nullptr;
-        m_ctx.wicConverterOriginal = nullptr;
+        // Keep current display resources alive until the replacement image is ready.
         m_ctx.undoStack.clear();
-        m_ctx.d2dBitmap = nullptr;
-        m_ctx.d2dBitmapHq = nullptr;
         m_ctx.isHqPending = false;
-        m_ctx.animationD2DBitmaps.clear();
-        m_ctx.isAnimated = false;
-        m_ctx.animationFrameConverters.clear();
-        m_ctx.animationFrameDelays.clear();
-        m_ctx.currentAnimationFrame = 0;
+        ++m_ctx.hqRenderSequenceId;
         m_ctx.originalContainerFormat = GUID_NULL;
-
-        // Reset view transforms for new image
-        m_ctx.rotationAngle = 0;
-        m_ctx.isFlippedHorizontal = false;
 
         m_ctx.stagedFrames.clear();
         m_ctx.stagedDelays.clear();
@@ -84,9 +73,6 @@ void ViewerApp::LoadImageFromFile(const std::wstring& filePath, bool startAtEnd)
         m_ctx.stagedHeight = 0;
         m_ctx.stagedOrientation = 1;
 
-        m_ctx.isSvg = false;
-        m_ctx.svgDocument = nullptr;
-        m_ctx.svgData.clear();
         m_ctx.stagedSvgData.clear();
     }
     m_ctx.currentFilePathOverride.clear();
@@ -462,6 +448,8 @@ void ViewerApp::OnImageReady(bool success, int seqId) {
             return;
         }
 
+        ClearCurrentImageDisplayState();
+
         if (!m_ctx.stagedSvgData.empty()) {
             m_ctx.svgData = std::move(m_ctx.stagedSvgData);
             m_ctx.isSvg = true;
@@ -480,11 +468,8 @@ void ViewerApp::OnImageReady(bool success, int seqId) {
             }
 
             m_ctx.isAnimated = animated;
-            m_ctx.animationFrameConverters.clear();
-            m_ctx.animationFrameDelays.clear();
 
             // Determine start frame
-            m_ctx.currentAnimationFrame = 0;
             if (m_ctx.startAtEnd && !animated && !m_ctx.stagedFrames.empty()) {
                 m_ctx.currentAnimationFrame = static_cast<UINT>(m_ctx.stagedFrames.size() - 1);
             }
@@ -653,6 +638,25 @@ void ViewerApp::CleanupLoadingThread() {
     m_ctx.cancelPreloading = true;
     CleanupPreloadingThreads();
     KillTimer(m_ctx.hWnd, ANIMATION_TIMER_ID);
+}
+
+void ViewerApp::ClearCurrentImageDisplayState() {
+    KillTimer(m_ctx.hWnd, ANIMATION_TIMER_ID);
+    m_ctx.wicConverter = nullptr;
+    m_ctx.wicConverterOriginal = nullptr;
+    m_ctx.d2dBitmap = nullptr;
+    m_ctx.d2dBitmapHq = nullptr;
+    m_ctx.isHqPending = false;
+    m_ctx.animationD2DBitmaps.clear();
+    m_ctx.animationFrameConverters.clear();
+    m_ctx.animationFrameDelays.clear();
+    m_ctx.currentAnimationFrame = 0;
+    m_ctx.isAnimated = false;
+    m_ctx.isSvg = false;
+    m_ctx.svgDocument = nullptr;
+    m_ctx.svgData.clear();
+    m_ctx.rotationAngle = 0;
+    m_ctx.isFlippedHorizontal = false;
 }
 
 void ViewerApp::CleanupPreloadingThreads() {

--- a/src/ui_handlers.cpp
+++ b/src/ui_handlers.cpp
@@ -41,20 +41,24 @@ void ViewerApp::OnKeyDown(WPARAM wParam) {
         if (!m_ctx.imageFiles.empty() && m_ctx.currentImageIndex != -1) {
             size_t size = m_ctx.imageFiles.size();
             m_ctx.currentImageIndex = (m_ctx.currentImageIndex + 1) % static_cast<int>(size);
+            m_ctx.pendingNavIndex = m_ctx.currentImageIndex;
+            m_ctx.startAtEnd = false;
             std::wstring title = PathFindFileNameW(m_ctx.imageFiles[m_ctx.currentImageIndex].c_str());
             title += L"  [Loading...]";
             SetWindowTextW(m_ctx.hWnd, title.c_str());
-            LoadImageFromFile(m_ctx.imageFiles[m_ctx.currentImageIndex], false);
+            SetTimer(m_ctx.hWnd, NAV_DEBOUNCE_TIMER_ID, 150, nullptr);
         }
     }
     else if (isKey(Act_Prev)) {
         if (!m_ctx.imageFiles.empty() && m_ctx.currentImageIndex != -1) {
             size_t size = m_ctx.imageFiles.size();
             m_ctx.currentImageIndex = (m_ctx.currentImageIndex - 1 + static_cast<int>(size)) % static_cast<int>(size);
+            m_ctx.pendingNavIndex = m_ctx.currentImageIndex;
+            m_ctx.startAtEnd = true;
             std::wstring title = PathFindFileNameW(m_ctx.imageFiles[m_ctx.currentImageIndex].c_str());
             title += L"  [Loading...]";
             SetWindowTextW(m_ctx.hWnd, title.c_str());
-            LoadImageFromFile(m_ctx.imageFiles[m_ctx.currentImageIndex], true);
+            SetTimer(m_ctx.hWnd, NAV_DEBOUNCE_TIMER_ID, 150, nullptr);
         }
     }
     else if (isKey(Act_ZoomIn)) {

--- a/src/ui_handlers.cpp
+++ b/src/ui_handlers.cpp
@@ -562,6 +562,13 @@ LRESULT ViewerApp::WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam
                     });
             }
         }
+        else if (wParam == NAV_DEBOUNCE_TIMER_ID) {
+            KillTimer(m_ctx.hWnd, NAV_DEBOUNCE_TIMER_ID);
+            if (m_ctx.pendingNavIndex != -1 && m_ctx.pendingNavIndex < m_ctx.imageFiles.size()) {
+                LoadImageFromFile(m_ctx.imageFiles[m_ctx.pendingNavIndex].c_str(), m_ctx.startAtEnd);
+                m_ctx.pendingNavIndex = -1;
+            }
+        }
         else if (wParam == AUTO_REFRESH_TIMER_ID) {
             if (m_ctx.isAutoRefresh && !m_ctx.isLoading && !m_ctx.imageFiles.empty() && m_ctx.currentImageIndex >= 0) {
                 const std::wstring& currentFile = m_ctx.imageFiles[m_ctx.currentImageIndex];
@@ -849,3 +856,4 @@ LRESULT ViewerApp::WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam
     }
     return 0;
 }
+

--- a/src/ui_handlers.cpp
+++ b/src/ui_handlers.cpp
@@ -41,24 +41,20 @@ void ViewerApp::OnKeyDown(WPARAM wParam) {
         if (!m_ctx.imageFiles.empty() && m_ctx.currentImageIndex != -1) {
             size_t size = m_ctx.imageFiles.size();
             m_ctx.currentImageIndex = (m_ctx.currentImageIndex + 1) % static_cast<int>(size);
-            m_ctx.pendingNavIndex = m_ctx.currentImageIndex;
-            m_ctx.startAtEnd = false;
             std::wstring title = PathFindFileNameW(m_ctx.imageFiles[m_ctx.currentImageIndex].c_str());
             title += L"  [Loading...]";
             SetWindowTextW(m_ctx.hWnd, title.c_str());
-            SetTimer(m_ctx.hWnd, NAV_DEBOUNCE_TIMER_ID, 150, nullptr);
+            LoadImageFromFile(m_ctx.imageFiles[m_ctx.currentImageIndex], false);
         }
     }
     else if (isKey(Act_Prev)) {
         if (!m_ctx.imageFiles.empty() && m_ctx.currentImageIndex != -1) {
             size_t size = m_ctx.imageFiles.size();
             m_ctx.currentImageIndex = (m_ctx.currentImageIndex - 1 + static_cast<int>(size)) % static_cast<int>(size);
-            m_ctx.pendingNavIndex = m_ctx.currentImageIndex;
-            m_ctx.startAtEnd = true;
             std::wstring title = PathFindFileNameW(m_ctx.imageFiles[m_ctx.currentImageIndex].c_str());
             title += L"  [Loading...]";
             SetWindowTextW(m_ctx.hWnd, title.c_str());
-            SetTimer(m_ctx.hWnd, NAV_DEBOUNCE_TIMER_ID, 150, nullptr);
+            LoadImageFromFile(m_ctx.imageFiles[m_ctx.currentImageIndex], true);
         }
     }
     else if (isKey(Act_ZoomIn)) {
@@ -562,13 +558,6 @@ LRESULT ViewerApp::WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam
                     });
             }
         }
-        else if (wParam == NAV_DEBOUNCE_TIMER_ID) {
-            KillTimer(m_ctx.hWnd, NAV_DEBOUNCE_TIMER_ID);
-            if (m_ctx.pendingNavIndex != -1 && m_ctx.pendingNavIndex < m_ctx.imageFiles.size()) {
-                LoadImageFromFile(m_ctx.imageFiles[m_ctx.pendingNavIndex].c_str(), m_ctx.startAtEnd);
-                m_ctx.pendingNavIndex = -1;
-            }
-        }
         else if (wParam == AUTO_REFRESH_TIMER_ID) {
             if (m_ctx.isAutoRefresh && !m_ctx.isLoading && !m_ctx.imageFiles.empty() && m_ctx.currentImageIndex >= 0) {
                 const std::wstring& currentFile = m_ctx.imageFiles[m_ctx.currentImageIndex];
@@ -856,4 +845,3 @@ LRESULT ViewerApp::WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam
     }
     return 0;
 }
-

--- a/src/viewer.h
+++ b/src/viewer.h
@@ -73,7 +73,8 @@ constexpr UINT OCR_MESSAGE_TIMER_ID = 2;
 constexpr UINT AUTO_REFRESH_TIMER_ID = 3;
 constexpr UINT LOADING_TIMER_ID = 4;
 constexpr UINT HQ_RENDER_TIMER_ID = 5;
-constexpr UINT KEYBINDING_TIMER_ID = 6;
+constexpr UINT NAV_DEBOUNCE_TIMER_ID = 6;
+constexpr UINT KEYBINDING_TIMER_ID = 7;
 
 class CriticalSectionLock {
 public:
@@ -156,6 +157,7 @@ struct AppContext {
     ComPtr<ID2D1Bitmap> d2dBitmapHq = nullptr;
     float hqZoomFactor = 1.0f;
     bool isHqPending = false;
+    int pendingNavIndex = -1;
     ComPtr<IWICFormatConverter> wicConverter = nullptr;
     ComPtr<IWICFormatConverter> wicConverterOriginal = nullptr;
     std::vector<ComPtr<IWICFormatConverter>> undoStack;
@@ -331,7 +333,6 @@ public:
     void OnImageReady(bool success, int seqId);
     void OnDirReady(int seqId);
     void CleanupLoadingThread();
-    void ClearCurrentImageDisplayState();
     void CleanupPreloadingThreads();
     void StartPreloading();
     std::vector<std::wstring> ScanDirectory(const std::wstring& directoryPath, int seqId);

--- a/src/viewer.h
+++ b/src/viewer.h
@@ -73,8 +73,7 @@ constexpr UINT OCR_MESSAGE_TIMER_ID = 2;
 constexpr UINT AUTO_REFRESH_TIMER_ID = 3;
 constexpr UINT LOADING_TIMER_ID = 4;
 constexpr UINT HQ_RENDER_TIMER_ID = 5;
-constexpr UINT NAV_DEBOUNCE_TIMER_ID = 6;
-constexpr UINT KEYBINDING_TIMER_ID = 7;
+constexpr UINT KEYBINDING_TIMER_ID = 6;
 
 class CriticalSectionLock {
 public:
@@ -157,7 +156,6 @@ struct AppContext {
     ComPtr<ID2D1Bitmap> d2dBitmapHq = nullptr;
     float hqZoomFactor = 1.0f;
     bool isHqPending = false;
-    int pendingNavIndex = -1;
     ComPtr<IWICFormatConverter> wicConverter = nullptr;
     ComPtr<IWICFormatConverter> wicConverterOriginal = nullptr;
     std::vector<ComPtr<IWICFormatConverter>> undoStack;
@@ -333,6 +331,7 @@ public:
     void OnImageReady(bool success, int seqId);
     void OnDirReady(int seqId);
     void CleanupLoadingThread();
+    void ClearCurrentImageDisplayState();
     void CleanupPreloadingThreads();
     void StartPreloading();
     std::vector<std::wstring> ScanDirectory(const std::wstring& directoryPath, int seqId);


### PR DESCRIPTION
Removes debounce on next/previous navigation. The image starts loading immediately, while the current image stays in view. It's replaced once a new image is loaded. The loading message is still shown when loading takes longer than 700ms.

The benefit is that navigation feels more responsive, while still avoiding flicker.

This is a behavioral change that I don't know if is something you want, since previously it would not start loading an image until the debounce was activated. But if the debounce was there mainly to fix the flicker, then I think the behavior in this PR is probably better, because it feels more responsive, while avoiding the loading -> image -> loading flicker.

I also experimented with throttling the navigation when loading. For example, when holding the left/right arrow, it would wait until the image was loaded, but that is probably not ideal, because if there was a large image, you'd have to wait for it to fully load to go to the next image.

I'm not 100% confident in the changes, as I just quickly used an LLM to guide me to the relevant code, so you should double-check it.

Fixes https://github.com/deminimis/minimalimageviewer/issues/48.